### PR TITLE
Add script to start both cmus and cmusCoverViewer; Add uninstall option to makefile

### DIFF
--- a/cmusv
+++ b/cmusv
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cmusCoverViewer &> /dev/null &
+coverViewerPID=$!
+cmus
+kill $coverViewerPID

--- a/makefile
+++ b/makefile
@@ -22,4 +22,8 @@ install: $(OUTNAME)
 	chmod 755 "/usr/local/bin/$(OUTNAME)"
 	cp -f cmusv "/usr/local/bin"
 
+uninstall: $(OUTNAME)
+	rm -f "/usr/local/bin/$(OUTNAME)"
+	rm -f "/usr/local/bin/cmusv"
+
 main.o: config.h

--- a/makefile
+++ b/makefile
@@ -20,5 +20,6 @@ clean:
 install: $(OUTNAME)
 	cp -f $(OUTNAME) "/usr/local/bin"
 	chmod 755 "/usr/local/bin/$(OUTNAME)"
+	cp -f cmusv "/usr/local/bin"
 
 main.o: config.h


### PR DESCRIPTION
This fixes https://github.com/MyLegGuy/cmusCoversSDL/issues/3 and adds an uninstall option to the makefile so people don't have to delete things manually from /usr/local/bin.